### PR TITLE
fix: preserve firewall state across reloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,10 @@ jobs:
         include:
           - os_arch: linux-amd64
             runner: ubuntu-latest
+            rust_target: x86_64-unknown-linux-musl
           - os_arch: linux-arm64
             runner: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-musl
 
     steps:
       - name: Checkout
@@ -36,6 +38,16 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+
+      - name: Install cargo-zigbuild
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-zigbuild
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -43,16 +55,21 @@ jobs:
           prefix-key: "release-${{ matrix.os_arch }}"
 
       - name: Build
-        run: cargo build --release
+        run: cargo zigbuild --release --target ${{ matrix.rust_target }}
 
       - name: Strip binary
-        run: strip target/release/fail2ban-rs
+        run: |
+          if command -v llvm-strip >/dev/null 2>&1; then
+            llvm-strip target/${{ matrix.rust_target }}/release/fail2ban-rs
+          elif command -v strip >/dev/null 2>&1; then
+            strip target/${{ matrix.rust_target }}/release/fail2ban-rs
+          fi
 
       - name: Package
         run: |
           ARTIFACT="fail2ban-rs-${VERSION}-${{ matrix.os_arch }}"
           mkdir -p dist/${ARTIFACT}
-          cp target/release/fail2ban-rs dist/${ARTIFACT}/
+          cp target/${{ matrix.rust_target }}/release/fail2ban-rs dist/${ARTIFACT}/
           cp dist/fail2ban-rs.service dist/${ARTIFACT}/
           cp config/default.toml dist/${ARTIFACT}/config.toml
           cp LICENSE dist/${ARTIFACT}/ 2>/dev/null || true

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -5,8 +5,8 @@
 # Prerequisites:
 #   brew install zig             (macOS cross-compilation)
 #   cargo install cargo-zigbuild
-#   rustup target add x86_64-unknown-linux-gnu
-#   rustup target add aarch64-unknown-linux-gnu
+#   rustup target add x86_64-unknown-linux-musl
+#   rustup target add aarch64-unknown-linux-musl
 
 set -e
 
@@ -38,8 +38,8 @@ rm -rf "$DIST_DIR"
 mkdir -p "$DIST_DIR"
 
 TARGETS=(
-    "x86_64-unknown-linux-gnu:linux-amd64"
-    "aarch64-unknown-linux-gnu:linux-arm64"
+    "x86_64-unknown-linux-musl:linux-amd64"
+    "aarch64-unknown-linux-musl:linux-arm64"
 )
 
 for target_pair in "${TARGETS[@]}"; do

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,7 @@ pub struct JailConfig {
     pub enabled: bool,
 
     /// Path to the log file to monitor.
+    #[serde(default)]
     pub log_path: PathBuf,
 
     /// Date format preset for timestamp extraction.
@@ -351,6 +352,12 @@ impl Config {
 
         if !jail.enabled {
             return Ok(());
+        }
+
+        if jail.log_backend == LogBackend::File && jail.log_path.as_os_str().is_empty() {
+            return Err(Error::config(format!(
+                "jail '{name}': log_path is required when log_backend = \"file\""
+            )));
         }
 
         if jail.filter.is_empty() {

--- a/src/enforce/mod.rs
+++ b/src/enforce/mod.rs
@@ -34,6 +34,7 @@ pub enum FirewallCmd {
         jail_id: String,
         banned_at: i64,
         expires_at: Option<i64>,
+        done: Option<oneshot::Sender<Result<()>>>,
     },
     /// Unban an IP in the firewall.
     Unban { ip: IpAddr, jail_id: String },
@@ -147,14 +148,21 @@ pub async fn run<S: ::std::hash::BuildHasher>(
             }
             cmd = rx.recv() => {
                 match cmd {
-                    Some(FirewallCmd::Ban { ip, jail_id, banned_at, expires_at }) => {
+                    Some(FirewallCmd::Ban { ip, jail_id, banned_at, expires_at, done }) => {
                         info!(%ip, jail = %jail_id, "banning");
-                        if let Some(backend) = backends.get(&jail_id) {
+                        let result = if let Some(backend) = backends.get(&jail_id) {
                             if let Err(e) = backend.ban(&ip, &jail_id).await {
                                 error!(%ip, jail = %jail_id, error = %e, "ban failed");
+                                Err(e)
+                            } else {
+                                Ok(())
                             }
                         } else {
                             warn!(%ip, jail = %jail_id, "no backend for jail");
+                            Ok(())
+                        };
+                        if let Some(done) = done {
+                            let _ = done.send(result);
                         }
                         let _ = (banned_at, expires_at);
                     }
@@ -377,6 +385,7 @@ mod tests {
             jail_id: "sshd".to_string(),
             banned_at: 1000,
             expires_at: Some(2000),
+            done: None,
         })
         .await
         .unwrap();
@@ -646,6 +655,7 @@ mod tests {
             jail_id: "sshd".to_string(),
             banned_at: 1000,
             expires_at: Some(2000),
+            done: None,
         })
         .await
         .unwrap();
@@ -655,6 +665,7 @@ mod tests {
             jail_id: "nginx".to_string(),
             banned_at: 1000,
             expires_at: Some(2000),
+            done: None,
         })
         .await
         .unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,9 +20,18 @@ use crate::enforce::{self, FirewallCmd};
 use crate::logging::Logger;
 use crate::track::TrackerCmd;
 use crate::track::persist::BanState;
+use crate::track::state::BanRecord;
+
+struct WatcherPlan {
+    name: String,
+    jail: crate::config::JailConfig,
+    matcher: JailMatcher,
+    date_parser: DateParser,
+    ignore_list: IgnoreList,
+}
 
 /// Run the daemon with the given configuration.
-pub async fn run(config: Config, config_path: PathBuf) -> crate::error::Result<()> {
+pub async fn run(mut config: Config, config_path: PathBuf) -> crate::error::Result<()> {
     let cancel = CancellationToken::new();
 
     // Initialize remote logging (no-op if not configured).
@@ -126,25 +135,7 @@ pub async fn run(config: Config, config_path: PathBuf) -> crate::error::Result<(
         enforce::run(executor_rx, backends, executor_cancel).await;
     });
 
-    // Initialize firewall rules for each jail and await confirmation.
-    for (name, jail) in config.enabled_jails() {
-        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
-        let cmd = enforce::FirewallCmd::InitJail {
-            jail_id: name.to_string(),
-            ports: jail.port.clone(),
-            protocol: jail.protocol.clone(),
-            done: done_tx,
-        };
-        if executor_tx.send(cmd).await.is_err() {
-            tracing::warn!(jail = %name, "failed to send init command");
-            continue;
-        }
-        match done_rx.await {
-            Ok(Ok(())) => info!(jail = %name, "firewall initialized"),
-            Ok(Err(e)) => error!(jail = %name, error = %e, "firewall init failed"),
-            Err(_) => tracing::warn!(jail = %name, "executor dropped init response"),
-        }
-    }
+    init_firewalls(&executor_tx, config.enabled_jails()).await?;
 
     // Log startup event.
     if let Some(t) = logger.as_ref() {
@@ -153,8 +144,9 @@ pub async fn run(config: Config, config_path: PathBuf) -> crate::error::Result<(
     }
 
     // Spawn watchers with their own cancellation token (for reload).
+    let watcher_plan = build_watcher_plan(&config)?;
     let mut watcher_cancel = CancellationToken::new();
-    spawn_watchers(&config, &failure_tx, &watcher_cancel)?;
+    spawn_watchers(watcher_plan, &failure_tx, &watcher_cancel);
 
     // Spawn tracker.
     let tracker_cancel = cancel.child_token();
@@ -193,24 +185,9 @@ pub async fn run(config: Config, config_path: PathBuf) -> crate::error::Result<(
     // Main select loop.
     loop {
         tokio::select! {
-            _ = tokio::signal::ctrl_c() => {
-                info!("received SIGINT, shutting down");
-                // Tear down firewall rules for each jail and await confirmation.
-                for (name, _) in config.enabled_jails() {
-                    let (done_tx, done_rx) = tokio::sync::oneshot::channel();
-                    let cmd = enforce::FirewallCmd::TeardownJail {
-                        jail_id: name.to_string(),
-                        done: done_tx,
-                    };
-                    if executor_tx.send(cmd).await.is_err() {
-                        break;
-                    }
-                    match done_rx.await {
-                        Ok(Ok(())) => info!(jail = %name, "firewall torn down"),
-                        Ok(Err(e)) => tracing::warn!(jail = %name, error = %e, "teardown failed"),
-                        Err(_) => break,
-                    }
-                }
+            _ = shutdown_signal() => {
+                info!("received shutdown signal, shutting down");
+                teardown_firewalls(&executor_tx, config.enabled_jails().map(|(name, _)| name)).await;
                 cancel.cancel();
                 watcher_cancel.cancel();
                 break;
@@ -220,9 +197,11 @@ pub async fn run(config: Config, config_path: PathBuf) -> crate::error::Result<(
                 info!("received SIGHUP, reloading config");
                 match reload_config(
                     &config_path,
+                    &executor_tx,
+                    &tracker_cmd_tx,
+                    &mut config,
                     &mut watcher_cancel,
                     &failure_tx_for_reload,
-                    &tracker_cmd_tx,
                     logger.as_ref(),
                 ).await {
                     Ok(()) => info!("config reload complete"),
@@ -236,6 +215,8 @@ pub async fn run(config: Config, config_path: PathBuf) -> crate::error::Result<(
                         ctrl.request,
                         &tracker_cmd_tx,
                         &config_path,
+                        &executor_tx,
+                        &mut config,
                         &mut watcher_cancel,
                         &failure_tx_for_reload,
                         logger.as_ref(),
@@ -260,33 +241,46 @@ pub async fn run(config: Config, config_path: PathBuf) -> crate::error::Result<(
     Ok(())
 }
 
+fn build_watcher_plan(config: &Config) -> crate::error::Result<Vec<WatcherPlan>> {
+    config
+        .enabled_jails()
+        .map(|(name, jail)| {
+            let matcher = if jail.ignoreregex.is_empty() {
+                JailMatcher::new(&jail.filter)?
+            } else {
+                JailMatcher::with_ignoreregex(&jail.filter, &jail.ignoreregex)?
+            };
+            let date_parser = DateParser::new(jail.date_format)?;
+            let ignore_list = IgnoreList::new(&jail.ignoreip, jail.ignoreself)?;
+            Ok(WatcherPlan {
+                name: name.to_string(),
+                jail: jail.clone(),
+                matcher,
+                date_parser,
+                ignore_list,
+            })
+        })
+        .collect()
+}
+
 fn spawn_watchers(
-    config: &Config,
+    watcher_plan: Vec<WatcherPlan>,
     failure_tx: &mpsc::Sender<Failure>,
     cancel: &CancellationToken,
-) -> crate::error::Result<()> {
-    for (name, jail) in config.enabled_jails() {
-        let matcher = if jail.ignoreregex.is_empty() {
-            JailMatcher::new(&jail.filter)?
-        } else {
-            JailMatcher::with_ignoreregex(&jail.filter, &jail.ignoreregex)?
-        };
-        let date_parser = DateParser::new(jail.date_format)?;
-        let ignore_list = IgnoreList::new(&jail.ignoreip, jail.ignoreself)?;
-
+) {
+    for plan in watcher_plan {
         let tx = failure_tx.clone();
         let cancel = cancel.child_token();
-        let name = name.to_string();
 
-        if jail.log_backend == crate::config::LogBackend::Systemd {
-            let journalmatch = jail.journalmatch.clone();
+        if plan.jail.log_backend == crate::config::LogBackend::Systemd {
+            let journalmatch = plan.jail.journalmatch.clone();
             tokio::spawn(async move {
                 crate::detect::journal::run(
-                    name,
+                    plan.name,
                     journalmatch,
-                    matcher,
-                    date_parser,
-                    ignore_list,
+                    plan.matcher,
+                    plan.date_parser,
+                    plan.ignore_list,
                     tx,
                     cancel,
                 )
@@ -295,40 +289,71 @@ fn spawn_watchers(
             continue;
         }
 
-        let log_path = jail.log_path.clone();
+        let log_path = plan.jail.log_path.clone();
         tokio::spawn(async move {
             crate::detect::watcher::run(
-                name,
+                plan.name,
                 log_path,
-                matcher,
-                date_parser,
-                ignore_list,
+                plan.matcher,
+                plan.date_parser,
+                plan.ignore_list,
                 tx,
                 cancel,
             )
             .await;
         });
     }
-    Ok(())
 }
 
 async fn reload_config(
     config_path: &std::path::Path,
+    executor_tx: &mpsc::Sender<FirewallCmd>,
+    tracker_cmd_tx: &mpsc::Sender<TrackerCmd>,
+    current_config: &mut Config,
     watcher_cancel: &mut CancellationToken,
     failure_tx: &mpsc::Sender<Failure>,
-    tracker_cmd_tx: &mpsc::Sender<TrackerCmd>,
     logger: Option<&Logger>,
 ) -> crate::error::Result<()> {
     // Parse and validate new config.
     let new_config = Config::from_file(config_path)?;
+    let new_watcher_plan = build_watcher_plan(&new_config)?;
+    let active_bans = query_active_bans(tracker_cmd_tx).await?;
 
-    // Cancel old watchers.
+    // Apply new firewall rules before touching the current watcher/tracker state.
+    teardown_firewalls(
+        executor_tx,
+        current_config.enabled_jails().map(|(name, _)| name),
+    )
+    .await;
+    if let Err(e) = init_firewalls(executor_tx, new_config.enabled_jails()).await {
+        let rollback_err =
+            rollback_firewalls(executor_tx, current_config, &new_config, &active_bans).await;
+        let message = if let Some(rollback_err) = rollback_err {
+            format!("{e}; rollback failed: {rollback_err}")
+        } else {
+            e.to_string()
+        };
+        return Err(crate::error::Error::firewall(message));
+    }
+
+    if let Err(e) = reapply_bans(executor_tx, &active_bans, &new_config).await {
+        let rollback_err =
+            rollback_firewalls(executor_tx, current_config, &new_config, &active_bans).await;
+        let message = if let Some(rollback_err) = rollback_err {
+            format!("{e}; rollback failed: {rollback_err}")
+        } else {
+            e.to_string()
+        };
+        return Err(crate::error::Error::firewall(message));
+    }
+
+    // Cancel old watchers only after the new config is known-good.
     watcher_cancel.cancel();
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     // Spawn new watchers with fresh token.
     let new_cancel = CancellationToken::new();
-    spawn_watchers(&new_config, failure_tx, &new_cancel)?;
+    spawn_watchers(new_watcher_plan, failure_tx, &new_cancel);
     *watcher_cancel = new_cancel;
 
     // Update tracker jail configs.
@@ -351,13 +376,136 @@ async fn reload_config(
         t.log_reload(jail_count);
     }
 
+    *current_config = new_config;
+
     Ok(())
+}
+
+async fn init_firewalls<'a>(
+    executor_tx: &mpsc::Sender<FirewallCmd>,
+    jails: impl Iterator<Item = (&'a str, &'a crate::config::JailConfig)>,
+) -> crate::error::Result<()> {
+    for (name, jail) in jails {
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let cmd = enforce::FirewallCmd::InitJail {
+            jail_id: name.to_string(),
+            ports: jail.port.clone(),
+            protocol: jail.protocol.clone(),
+            done: done_tx,
+        };
+        if executor_tx.send(cmd).await.is_err() {
+            return Err(crate::error::Error::ChannelClosed);
+        }
+        match done_rx.await {
+            Ok(Ok(())) => info!(jail = %name, "firewall initialized"),
+            Ok(Err(e)) => {
+                error!(jail = %name, error = %e, "firewall init failed");
+                return Err(e);
+            }
+            Err(_) => return Err(crate::error::Error::ChannelClosed),
+        }
+    }
+
+    Ok(())
+}
+
+async fn teardown_firewalls<'a>(
+    executor_tx: &mpsc::Sender<FirewallCmd>,
+    jail_names: impl Iterator<Item = &'a str>,
+) {
+    for name in jail_names {
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let cmd = enforce::FirewallCmd::TeardownJail {
+            jail_id: name.to_string(),
+            done: done_tx,
+        };
+        if executor_tx.send(cmd).await.is_err() {
+            break;
+        }
+        match done_rx.await {
+            Ok(Ok(())) => info!(jail = %name, "firewall torn down"),
+            Ok(Err(e)) => tracing::warn!(jail = %name, error = %e, "teardown failed"),
+            Err(_) => break,
+        }
+    }
+}
+
+async fn query_active_bans(
+    tracker_cmd_tx: &mpsc::Sender<TrackerCmd>,
+) -> crate::error::Result<Vec<BanRecord>> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tracker_cmd_tx
+        .send(TrackerCmd::QueryBans { respond: tx })
+        .await
+        .map_err(|_| crate::error::Error::ChannelClosed)?;
+    rx.await.map_err(|_| crate::error::Error::ChannelClosed)
+}
+
+async fn reapply_bans(
+    executor_tx: &mpsc::Sender<FirewallCmd>,
+    active_bans: &[BanRecord],
+    config: &Config,
+) -> crate::error::Result<()> {
+    let enabled_jails: std::collections::HashSet<&str> =
+        config.enabled_jails().map(|(name, _)| name).collect();
+
+    for ban in active_bans {
+        if !enabled_jails.contains(ban.jail_id.as_str()) {
+            continue;
+        }
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let cmd = FirewallCmd::Ban {
+            ip: ban.ip,
+            jail_id: ban.jail_id.clone(),
+            banned_at: ban.banned_at,
+            expires_at: ban.expires_at,
+            done: Some(done_tx),
+        };
+        executor_tx
+            .send(cmd)
+            .await
+            .map_err(|_| crate::error::Error::ChannelClosed)?;
+        match done_rx.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e),
+            Err(_) => return Err(crate::error::Error::ChannelClosed),
+        }
+    }
+
+    Ok(())
+}
+
+async fn rollback_firewalls(
+    executor_tx: &mpsc::Sender<FirewallCmd>,
+    current_config: &Config,
+    attempted_config: &Config,
+    active_bans: &[BanRecord],
+) -> Option<crate::error::Error> {
+    teardown_firewalls(
+        executor_tx,
+        attempted_config.enabled_jails().map(|(name, _)| name),
+    )
+    .await;
+    teardown_firewalls(
+        executor_tx,
+        current_config.enabled_jails().map(|(name, _)| name),
+    )
+    .await;
+    if let Err(e) = init_firewalls(executor_tx, current_config.enabled_jails()).await {
+        return Some(e);
+    }
+    if let Err(e) = reapply_bans(executor_tx, active_bans, current_config).await {
+        return Some(e);
+    }
+    None
 }
 
 async fn handle_control_request(
     request: Request,
     tracker_cmd_tx: &mpsc::Sender<TrackerCmd>,
     config_path: &std::path::Path,
+    executor_tx: &mpsc::Sender<FirewallCmd>,
+    config: &mut Config,
     watcher_cancel: &mut CancellationToken,
     failure_tx: &mpsc::Sender<Failure>,
     logger: Option<&Logger>,
@@ -437,9 +585,11 @@ async fn handle_control_request(
         Request::Reload => {
             match reload_config(
                 config_path,
+                executor_tx,
+                tracker_cmd_tx,
+                config,
                 watcher_cancel,
                 failure_tx,
-                tracker_cmd_tx,
                 logger,
             )
             .await
@@ -483,9 +633,41 @@ async fn signal_sighup() {
     stream.recv().await;
 }
 
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut sigint = match signal(SignalKind::interrupt()) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to register SIGINT handler");
+            std::future::pending::<()>().await;
+            return;
+        }
+    };
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to register SIGTERM handler");
+            std::future::pending::<()>().await;
+            return;
+        }
+    };
+
+    tokio::select! {
+        _ = sigint.recv() => {}
+        _ = sigterm.recv() => {}
+    }
+}
+
 #[cfg(not(unix))]
 async fn signal_sighup() {
     std::future::pending::<()>().await;
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
 }
 
 #[cfg(test)]

--- a/src/track/mod.rs
+++ b/src/track/mod.rs
@@ -392,6 +392,7 @@ async fn execute_ban(ip: IpAddr, jail_id: &str, ban_time: i64, manual: bool, s: 
         jail_id: jail_id.to_string(),
         banned_at: now,
         expires_at,
+        done: None,
     };
     if s.executor_tx.send(cmd).await.is_err() {
         warn!("executor channel closed");


### PR DESCRIPTION
## Summary

Fix reload behavior so firewall state is preserved correctly.

## Changes

- allow `log_backend = "systemd"` without requiring `log_path`
- validate watcher setup before switching runtime state
- reapply active bans after firewall reload
- return reload errors when firewall init/reapply fails
- handle both `SIGINT` and `SIGTERM` for cleanup

## Why

Previously, reload could:

- drop active bans from the firewall
- leave stale nftables rules behind
- report reload success even when firewall setup failed

This change makes reload safer and more predictable.